### PR TITLE
scripts/create_setup.sh: fix github CI problem

### DIFF
--- a/scripts/create_setup.sh
+++ b/scripts/create_setup.sh
@@ -256,6 +256,9 @@ if [ "$TBOTCONFIGEXISTS" == "no" ];then
 	# for github CI we need sispmctl for board we use for testing
 	sed -i "s|@@SISPMCTRLMAC@@|01:01:4f:09:5b|g" ./tbotconfig/$BOARDNAME/tbot.ini
 	sed -i "s|@@SISPMCTRLPORT@@|1|g" ./tbotconfig/$BOARDNAME/tbot.ini
+	delete_line ./tbotconfig/$BOARDNAME/tbot.ini "GPIOPMCTRL_$BOARDNAME" 2
+	delete_line ./tbotconfig/$BOARDNAME/tbot.ini "POWERSHELLSCRIPT_$BOARDNAME" 1
+	delete_line ./tbotconfig/$BOARDNAME/tbot.ini "TF_$BOARDNAME" 2
 
 	#sed -i "s|@@@@|$|g" ./tbotconfig/$BOARDNAME/tbot.ini
 fi


### PR DESCRIPTION
fix github CI error:

configparser.NoOptionError: No option '***n' in section: 'GPIOPMCTRL_foo'